### PR TITLE
Fix melee characters not returning to anchor after combat

### DIFF
--- a/backend/src/game/character-state.service.spec.ts
+++ b/backend/src/game/character-state.service.spec.ts
@@ -79,6 +79,13 @@ const mockPlayerStateStore = {
     }
     return true;
   }),
+  setCharacterAnchor: jest.fn().mockImplementation((_zoneId: string, _charId: string, anchorX: number, anchorY: number) => {
+    if (currentTestCharacter && currentTestCharacter.id === _charId) {
+      currentTestCharacter.anchorX = anchorX;
+      currentTestCharacter.anchorY = anchorY;
+    }
+    return true;
+  }),
   setAttackTarget: jest.fn().mockImplementation((_zoneId: string, charId: string, targetId: string) => {
     // Simulates the real store: looks up enemy via enemyStateStore internally
     const enemy = mockEnemyStateStore.getEnemyInstanceById(_zoneId, targetId);

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -644,7 +644,10 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
               target.targetX,
               target.targetY
           );
-          if (!success) {
+          if (success) {
+              // Player-initiated move: update anchor to new station position
+              this.playerStateStore.setCharacterAnchor(zoneId, target.charId, target.targetX, target.targetY);
+          } else {
               this.logger.warn(`[MoveCmd] Failed to set movement target for char ${target.charId} via ZoneService.`);
           }
       }

--- a/backend/src/game/stores/player-state.store.ts
+++ b/backend/src/game/stores/player-state.store.ts
@@ -376,8 +376,6 @@ export class PlayerStateStore {
 
         character.targetX = targetX;
         character.targetY = targetY;
-        character.anchorX = targetX;
-        character.anchorY = targetY;
         character.attackTargetId = null;
         character.targetItemId = null;
         character.commandState = null;
@@ -453,6 +451,14 @@ export class PlayerStateStore {
         }
         this.logger.warn(`[PlayerStateStore] Failed to set loot area state for character ${characterId} (User: ${userId}). Not found or dead.`);
         return false;
+    }
+
+    setCharacterAnchor(zoneId: string, characterId: string, anchorX: number, anchorY: number): boolean {
+        const character = this.findCharacterInZone(zoneId, characterId);
+        if (!character) return false;
+        character.anchorX = anchorX;
+        character.anchorY = anchorY;
+        return true;
     }
 
     // Alias used by attacking.state.ts


### PR DESCRIPTION
## Summary
- **Root cause:** `setMovementTarget()` unconditionally overwrote `anchorX`/`anchorY`. When `attacking.state.ts` called it to walk toward an enemy, the anchor silently moved to the enemy's position. After combat, idle state saw the character was at "anchor" and never leashed back.
- **Fix:** Removed anchor updates from `setMovementTarget()`, added explicit `setCharacterAnchor()` method on `PlayerStateStore`, and call it only from the player move command in `GameGateway` — the only caller that represents player intent to reposition.
- Updated test mock in `character-state.service.spec.ts` to include `setCharacterAnchor`.

## Files changed
| File | Change |
|------|--------|
| `backend/src/game/stores/player-state.store.ts` | Removed anchor overwrite from `setMovementTarget()`, added `setCharacterAnchor()` |
| `backend/src/game/game.gateway.ts` | Call `setCharacterAnchor()` on successful player move command |
| `backend/src/game/character-state.service.spec.ts` | Added `setCharacterAnchor` mock |

## Caller analysis
| Caller | Should update anchor? | Before | After |
|--------|----------------------|--------|-------|
| Player move command (`game.gateway.ts:641`) | **Yes** (player intent) | ✅ via setMovementTarget | ✅ via setCharacterAnchor |
| Walk toward enemy (`attacking.state.ts:88`) | **No** (THE BUG) | ❌ overwrote anchor | ✅ anchor preserved |
| Return to anchor (`idle.state.ts:65`) | No (targets anchor anyway) | harmless | ✅ no change |
| Leash return (`character-state.service.ts:159`) | No (targets anchor anyway) | harmless | ✅ no change |
| Return after loot (`looting-area.state.ts:73`) | No (targets anchor anyway) | harmless | ✅ no change |

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx jest --no-coverage` — all 151 tests pass
- [ ] Manual: station character at A → aggro enemy → fight → enemy dies → character walks back to A
- [ ] Manual: character fights multiple enemies in sequence → anchor stays at A throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)